### PR TITLE
Fix to run the script with other pre-commit hooks.

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -1,2 +1,3 @@
 Daniel Roschka <daniel@smaato.com>
 Denny Schäfer <denny.schaefer@smaato.com>
+Andreas Gerler <andreas.gerler@smaato.com>

--- a/pre-commit
+++ b/pre-commit
@@ -9,7 +9,8 @@ the following things:
 
 Author: Daniel Roschka <daniel@smaato.com>
 Author: Denny Schäfer <denny.schaefer@smaato.com>
-Copyright: Smaato Inc. 2013-2015
+Author: Andreas Gerler <andreas.gerler@smaato.com>
+Copyright: Smaato Inc. 2013-2016
 URL: https://github.com/smaato/puppet-git-hook
 """
 
@@ -255,7 +256,7 @@ if __name__ == '__main__':
             print("Problem while trying to remove the temporary cloned repository.")
             sys.exit(1)
 
-    elif script_name == 'pre-commit':
+    elif script_name.startswith('pre-commit'):
         # stash changes which aren't being committed during this commit
         stashed_diff, error = subprocess.Popen(['git', 'diff', '--full-index', '--binary'],
                                                stdout=subprocess.PIPE,


### PR DESCRIPTION
- Now the script can also be called as pre-commit.1 to run with other
  pre-commit hooks.

Signed-off-by: Andreas Gerler andreas.gerler@smaato.com
